### PR TITLE
v1.0.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+on:
+  push:
+    branches: [ "main", "dev" ]
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.24.0"
+      - name: Check code
+        run: go fmt ./...
+

--- a/flags/init_flag.go
+++ b/flags/init_flag.go
@@ -13,6 +13,7 @@ var Config struct {
 	NapCatPanelURL string
 	NapCatToken    string
 	Login          bool
+	Version        string
 }
 
 func InitFlag() bool {
@@ -29,6 +30,7 @@ func InitFlag() bool {
 	flag.StringVar(&Config.NapCatPanelURL, "ncpanel", "http://127.0.0.1:6099", "NapCat Panel URL")
 	flag.StringVar(&Config.NapCatToken, "nctoken", "token", "NapCat Token")
 	flag.BoolVar(&Config.Login, "login", true, "Login to NapCat Panel")
+	flag.StringVar(&Config.Version, "version", "", "Update NapCat Version")
 	flag.Parse()
 	return true
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Sn0wo2/NapCatShellUpdater
 
-go 1.24rc2
+go 1.24
 
 require (
 	github.com/shirou/gopsutil v2.21.11+incompatible
@@ -17,5 +17,5 @@ require (
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
-golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -41,7 +41,12 @@ $$ | \$$ \$$$$$$$ $$$$$$$  \$$$$$$  \$$$$$$$ |\$$$$  \$$$$$$  $$ |  $$ \$$$$$$$\
 }
 
 func main() {
-	napcat.CheckNapCatUpdate()
+	cv := flags.Config.Version
+	if cv == "" {
+		napcat.CheckNapCatUpdate()
+	} else {
+		napcat.ProcessVersionUpdate(cv)
+	}
 	if flags.Config.Login {
 		log.Info("NapCatShellUpdater", "Wating NapCat process to login...")
 		ncProc, err := napcat.WaitForProcess(filepath.Join(flags.Config.Path, "NapCatWinBootMain.exe"))


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

此 pull request 引入了一项新功能，允许使用命令行 flag 将 NapCat 更新到特定版本。它还通过直接构造下载 URL 来增强更新过程。此外，它还包括对构建配置的更新，并添加了用于代码格式化和依赖项管理的 CI 工作流程。

新功能：
- 添加了一个新的 `-version` flag，允许将 NapCat 更新到特定版本。

增强功能：
- 通过直接从版本构造下载 URL，而不是依赖于解析 GitHub API 响应，改进了 NapCat 更新过程。
- 应用程序现在会先通过命令行 flag 检查指定的版本，然后再尝试获取最新版本，从而允许进行有针对性的更新。

构建：
- 在 go.mod 中将 go 版本更新到 1.24。

CI：
- 添加了一个 GitHub Actions 工作流程，用于代码格式化检查。
- 添加了一个 Dependabot 配置文件，用于管理依赖项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request introduces a new feature to update NapCat to a specific version using a command-line flag. It also enhances the update process by directly constructing the download URL. Additionally, it includes updates to the build configuration and adds CI workflows for code formatting and dependency management.

New Features:
- Adds a new `-version` flag to allow updating NapCat to a specific version.

Enhancements:
- Improves the NapCat update process by directly constructing the download URL from the version, instead of relying on parsing the GitHub API response.
- The application now checks for a specified version via the command line flag before attempting to fetch the latest version, allowing for targeted updates.

Build:
- Updates the go version to 1.24 in go.mod.

CI:
- Adds a GitHub Actions workflow for code formatting checks.
- Adds a Dependabot configuration file for managing dependencies.

</details>