### PR TITLE
v1.0.7

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -39,7 +39,7 @@ func InitLogger(logPath string, formatter *easy.Formatter, logLevel logrus.Level
 }
 
 // Log a message with a prefix at the specified level.
-func logWithPrefix(level logrus.Level, prefix string, args ...interface{}) {
+func logWithPrefix(level logrus.Level, prefix string, args ...any) {
 	entry := Logger.WithField("prefix", prefix)
 	switch level {
 	case logrus.TraceLevel:
@@ -60,73 +60,73 @@ func logWithPrefix(level logrus.Level, prefix string, args ...interface{}) {
 }
 
 // Trace logs a message at level Trace with a prefix.
-func Trace(prefix string, args ...interface{}) {
+func Trace(prefix string, args ...any) {
 	logWithPrefix(logrus.TraceLevel, prefix, args...)
 }
 
 // Debug logs a message at level Debug with a prefix.
-func Debug(prefix string, args ...interface{}) {
+func Debug(prefix string, args ...any) {
 	logWithPrefix(logrus.DebugLevel, prefix, args...)
 }
 
 // Info logs a message at level Info with a prefix.
-func Info(prefix string, args ...interface{}) {
+func Info(prefix string, args ...any) {
 	logWithPrefix(logrus.InfoLevel, prefix, args...)
 }
 
 // Warning logs a message at level Warning with a prefix.
-func Warning(prefix string, args ...interface{}) {
+func Warning(prefix string, args ...any) {
 	logWithPrefix(logrus.WarnLevel, prefix, args...)
 }
 
 // Warn logs a message at level Warn with a prefix.
-func Warn(prefix string, args ...interface{}) {
+func Warn(prefix string, args ...any) {
 	logWithPrefix(logrus.WarnLevel, prefix, args...)
 }
 
 // Error logs a message at level Error with a prefix.
-func Error(prefix string, args ...interface{}) {
+func Error(prefix string, args ...any) {
 	logWithPrefix(logrus.ErrorLevel, prefix, args...)
 }
 
 // Panic logs a message at level Panic with a prefix.
-func Panic(prefix string, args ...interface{}) {
+func Panic(prefix string, args ...any) {
 	logWithPrefix(logrus.PanicLevel, prefix, args...)
 }
 
 // Fatal logs a message at level Fatal with a prefix.
-func Fatal(prefix string, args ...interface{}) {
+func Fatal(prefix string, args ...any) {
 	logWithPrefix(logrus.FatalLevel, prefix, args...)
 }
 
 // RPanic logs a message at level Error with stack trace, without exiting the program.
-func RPanic(data ...interface{}) {
+func RPanic(args ...any) {
 	buf := make([]byte, 4096)
 	n := runtime.Stack(buf, false)
 	if n < len(buf) {
 		buf = buf[:n]
 	}
 
-	Error("panic", TrimJSONArray(fmt.Sprint(data...)), "\n", helper.BytesToString(buf))
+	Error("panic", TrimJSONArray(fmt.Sprint(args...)), "\n", helper.BytesToString(buf))
 }
 
 // TrimJSONArray trims the JSON array from the string for print
-func TrimJSONArray(data string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(data, "["), "]")
+func TrimJSONArray(json string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(json, "["), "]")
 }
 
-// FormatInterfaceToJSON formats an object into a JSON string.
+// FormatJSON formats an object into a JSON string.
 // Returns an empty string if an error occurs.
-func FormatInterfaceToJSON(data ...interface{}) string {
-	if len(data) == 1 {
-		bytes, err := json.Marshal(data[0])
+func FormatJSON(args ...any) string {
+	if len(args) == 1 {
+		bytes, err := json.Marshal(args[0])
 		if err != nil {
 			RPanic("failed to format JSON", err)
 			return ""
 		}
 		return helper.BytesToString(bytes)
 	} else {
-		bytes, err := json.Marshal(data)
+		bytes, err := json.Marshal(args)
 		if err != nil {
 			RPanic("failed to format JSON", err)
 			return ""

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Sn0wo2/NapCatShellUpdater/napcat"
 	"github.com/Sn0wo2/NapCatShellUpdater/napcat/login"
 	"github.com/sirupsen/logrus"
-	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime"

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Sn0wo2/NapCatShellUpdater/napcat"
 	"github.com/Sn0wo2/NapCatShellUpdater/napcat/login"
 	"github.com/sirupsen/logrus"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -60,6 +61,17 @@ func main() {
 		log.Debug("NapCatShellUpdater", "Waiting 30s to full load NapCat")
 		time.Sleep(30 * time.Second)
 		log.Info("NapCatShellUpdater", "Login to NapCat Panel...")
+		if flags.Config.NapCatPanelURL == "" || flags.Config.NapCatToken == "" {
+			log.Error("NapCatShellUpdater", "NapCatPanelURL or NapCatToken is empty, trying find NapCat Panel url and token in logs...")
+			url, token, err := login.GetNapCatPanelURLInLogs(filepath.Join(flags.Config.Path, "logs"))
+			if err != nil {
+				panic(err)
+			}
+			flags.Config.NapCatPanelURL = url
+			flags.Config.NapCatToken = token
+		}
+		log.Debug("NapCatShellUpdater", "Panel URL: ", flags.Config.NapCatPanelURL)
+		log.Debug("NapCatShellUpdater", "Panel Token: ", flags.Config.NapCatToken)
 		login.NapCatLogin()
 	}
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Sn0wo2/NapCatShellUpdater/napcat"
 	"github.com/Sn0wo2/NapCatShellUpdater/napcat/login"
 	"github.com/sirupsen/logrus"
-	"os"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -54,15 +53,14 @@ func main() {
 		case p := <-ncProc:
 			log.Debug("NapCatShellUpdater", "NapCat process found:", p.String())
 		case e := <-err:
-			log.Error("NapCatShellUpdater", "Failed to find NapCat process:", e)
-			os.Exit(1)
+			panic(e)
 		}
 		log.Debug("NapCatShellUpdater", "Waiting 30s to full load NapCat")
 		time.Sleep(30 * time.Second)
 		log.Info("NapCatShellUpdater", "Login to NapCat Panel...")
 		if flags.Config.NapCatPanelURL == "" || flags.Config.NapCatToken == "" {
 			log.Error("NapCatShellUpdater", "NapCatPanelURL or NapCatToken is empty, trying find NapCat Panel url and token in logs...")
-			url, token, err := login.GetNapCatPanelURLInLogs(filepath.Join(flags.Config.Path, "logs"))
+			url, token, err := napcat.GetNapCatPanelURLInLogs(filepath.Join(flags.Config.Path, "logs"))
 			if err != nil {
 				panic(err)
 			}

--- a/napcat/check.go
+++ b/napcat/check.go
@@ -25,18 +25,25 @@ func CheckNapCatUpdate() {
 }
 
 func ProcessVersionUpdate(ver string) {
-	if ver == "" {
+	currentVersion := getCurrentNapCatVersion()
+	if ver == "" || currentVersion == "" {
+		log.Error("NapCatShellUpdater", "Failed to fetch version info", ver, currentVersion)
 		return
 	}
-	processAndUpdate(downloadFile(fmt.Sprintf("https://github.com/NapNeko/NapCatQQ/releases/download/%s/NapCat.Shell.zip", ver)))
+	if ver != currentVersion {
+		processAndUpdate(downloadFile(fmt.Sprintf("https://github.com/NapNeko/NapCatQQ/releases/download/%s/NapCat.Shell.zip", ver)))
+	} else {
+		log.Info("NapCatShellUpdater", "NapCat is up to date: ", currentVersion)
+	}
 }
 
 func getCurrentNapCatVersion() (ver string) {
-	data, err := os.ReadFile(filepath.Join(flags.Config.Path, "package.json"))
+	packageFile, err := os.ReadFile(filepath.Join(flags.Config.Path, "package.json"))
 	if err != nil {
-		panic(err)
+		log.Error("NapCatShellUpdater", "failed to read package.json:", err)
+		return "v0.0.0(Error)"
 	}
-	version := gjson.GetBytes(data, "version").String()
+	version := gjson.GetBytes(packageFile, "version").String()
 	if version == "" {
 		version = "0.0.0(Not Found)"
 	}

--- a/napcat/check.go
+++ b/napcat/check.go
@@ -1,6 +1,7 @@
 package napcat
 
 import (
+	"bufio"
 	"fmt"
 	"github.com/Sn0wo2/NapCatShellUpdater/flags"
 	"github.com/Sn0wo2/NapCatShellUpdater/helper"
@@ -11,6 +12,10 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
 )
 
 func CheckNapCatUpdate() {
@@ -34,6 +39,92 @@ func ProcessVersionUpdate(ver string) {
 		processAndUpdate(downloadFile(fmt.Sprintf("https://github.com/NapNeko/NapCatQQ/releases/download/%s/NapCat.Shell.zip", ver)))
 	} else {
 		log.Info("NapCatShellUpdater", "NapCat is up to date: ", currentVersion)
+	}
+}
+
+func GetNapCatPanelURLInLogs(dirPath string) (string, string, error) {
+	fileInfo, err := os.Stat(dirPath)
+	if err != nil || !fileInfo.IsDir() {
+		return "", "", fmt.Errorf("invalid directory path: %s", dirPath)
+	}
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read directory: %v", err)
+	}
+	urlTokenRegex := regexp.MustCompile(`(https?://[^\s:/]+:\d+)/webui\?token=([^\s]+)`)
+	var logFiles []struct {
+		Path    string
+		ModTime time.Time
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || strings.ToLower(filepath.Ext(entry.Name())) != ".log" {
+			continue
+		}
+
+		fullPath := filepath.Join(dirPath, entry.Name())
+		fileInfo, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		logFiles = append(logFiles, struct {
+			Path    string
+			ModTime time.Time
+		}{
+			Path:    fullPath,
+			ModTime: fileInfo.ModTime(),
+		})
+	}
+
+	if len(logFiles) == 0 {
+		return "", "", fmt.Errorf("no log files found in %s", dirPath)
+	}
+
+	sort.Slice(logFiles, func(i, j int) bool {
+		return logFiles[i].ModTime.After(logFiles[j].ModTime)
+	})
+
+	for _, logFile := range logFiles {
+		f, err := os.Open(logFile.Path)
+		if err != nil {
+			continue
+		}
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			matches := urlTokenRegex.FindStringSubmatch(scanner.Text())
+			if len(matches) >= 3 {
+				return matches[1], matches[2], nil
+			}
+		}
+	}
+
+	return "", "", fmt.Errorf("no matching URL found in %s", dirPath)
+}
+
+func processAndUpdate(filename string) {
+	log.Info("NapCatShellUpdater", "Waiting NapCatWinBootMain.exe process to end...")
+	err := <-WaitForAllProcessesEnd(filepath.Join(flags.Config.Path, "NapCatWinBootMain.exe"), true)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Info("NapCatShellUpdater", "Clean target directory...")
+	err = cleanDirectory(flags.Config.Path, []string{"config", "logs", "quickLoginExample.bat", "update.bat", filepath.Base(os.Args[0]), filename})
+	if err != nil {
+		log.RPanic(err)
+	}
+
+	log.Info("NapCatShellUpdater", "Extracting new version...")
+	err = unzipWithExclusion(filename, flags.Config.Path, []string{"quickLoginExample.bat"})
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.Remove(filename)
+	if err != nil {
+		panic(err)
 	}
 }
 

--- a/napcat/login/panel.go
+++ b/napcat/login/panel.go
@@ -1,7 +1,6 @@
 package login
 
 import (
-	"bufio"
 	"fmt"
 	"github.com/Sn0wo2/NapCatShellUpdater/flags"
 	"github.com/Sn0wo2/NapCatShellUpdater/helper"
@@ -9,10 +8,6 @@ import (
 	"github.com/tidwall/gjson"
 	"io"
 	"net/http"
-	"os"
-	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"time"
 )
@@ -26,76 +21,6 @@ func NapCatLogin() {
 		}
 		setNapCatQuickLogin(token, loginList)
 	}
-}
-
-func GetNapCatPanelURLInLogs(dirPath string) (string, string, error) {
-	// 验证目录路径
-	fileInfo, err := os.Stat(dirPath)
-	if err != nil || !fileInfo.IsDir() {
-		return "", "", fmt.Errorf("invalid directory path: %s", dirPath)
-	}
-
-	// 读取目录条目
-	entries, err := os.ReadDir(dirPath)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to read directory: %v", err)
-	}
-
-	// 预编译正则表达式
-	urlTokenRegex := regexp.MustCompile(`(https?://[^\s:/]+:\d+)/webui\?token=([^\s]+)`)
-
-	// 收集并排序日志文件
-	var logFiles []struct {
-		Path    string
-		ModTime time.Time
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || strings.ToLower(filepath.Ext(entry.Name())) != ".log" {
-			continue
-		}
-
-		fullPath := filepath.Join(dirPath, entry.Name())
-		fileInfo, err := entry.Info()
-		if err != nil {
-			continue
-		}
-
-		logFiles = append(logFiles, struct {
-			Path    string
-			ModTime time.Time
-		}{
-			Path:    fullPath,
-			ModTime: fileInfo.ModTime(),
-		})
-	}
-
-	if len(logFiles) == 0 {
-		return "", "", fmt.Errorf("no log files found in %s", dirPath)
-	}
-
-	// 按修改时间排序（最新优先）
-	sort.Slice(logFiles, func(i, j int) bool {
-		return logFiles[i].ModTime.After(logFiles[j].ModTime)
-	})
-
-	// 检查每个日志文件
-	for _, logFile := range logFiles {
-		f, err := os.Open(logFile.Path)
-		if err != nil {
-			continue
-		}
-		defer f.Close()
-
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			matches := urlTokenRegex.FindStringSubmatch(scanner.Text())
-			if len(matches) >= 3 {
-				return matches[1], matches[2], nil
-			}
-		}
-	}
-
-	return "", "", fmt.Errorf("no matching URL found in %s", dirPath)
 }
 
 func loginNapCatPanel() (token string) {

--- a/napcat/process.go
+++ b/napcat/process.go
@@ -1,38 +1,9 @@
 package napcat
 
 import (
-	"github.com/Sn0wo2/NapCatShellUpdater/flags"
-	"github.com/Sn0wo2/NapCatShellUpdater/log"
 	"github.com/shirou/gopsutil/process"
-	"os"
-	"path/filepath"
 	"time"
 )
-
-func processAndUpdate(filename string) {
-	log.Info("NapCatShellUpdater", "Waiting NapCatWinBootMain.exe process to end...")
-	err := <-WaitForAllProcessesEnd(filepath.Join(flags.Config.Path, "NapCatWinBootMain.exe"), true)
-	if err != nil {
-		panic(err)
-	}
-
-	log.Info("NapCatShellUpdater", "Clean target directory...")
-	err = cleanDirectory(flags.Config.Path, []string{"config", "logs", "quickLoginExample.bat", "update.bat", filepath.Base(os.Args[0]), filename})
-	if err != nil {
-		log.RPanic(err)
-	}
-
-	log.Info("NapCatShellUpdater", "Extracting new version...")
-	err = unzipWithExclusion(filename, flags.Config.Path, []string{"quickLoginExample.bat"})
-	if err != nil {
-		panic(err)
-	}
-
-	err = os.Remove(filename)
-	if err != nil {
-		panic(err)
-	}
-}
 
 func WaitForProcess(targetPath string) (<-chan *process.Process, <-chan error) {
 	resultChan := make(chan *process.Process)

--- a/napcat/process.go
+++ b/napcat/process.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Sn0wo2/NapCatShellUpdater/flags"
 	"github.com/Sn0wo2/NapCatShellUpdater/log"
 	"github.com/shirou/gopsutil/process"
-
 	"os"
 	"path/filepath"
 	"time"


### PR DESCRIPTION
直接读取logs的形式获得panel url和token

好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

此拉取请求引入了从日志文件中自动检索 NapCat Panel URL 和令牌的功能，通过添加版本检查改进了 NapCat 更新过程，并修复了读取 package.json 文件时的错误处理问题。

新功能：
- 引入了一项新功能，如果配置中未提供 NapCat Panel URL 和令牌，则可以从日志文件中自动检索它们。

Bug 修复：
- 修复了如果无法读取 package.json 文件，应用程序会崩溃的问题，现在它会记录错误并返回默认版本。

增强功能：
- 通过在尝试下载和更新之前检查当前版本是否与最新的可用版本匹配，从而改进了 NapCat 更新过程。

<details>
<summary>Original summary in English</summary>

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

此 pull request 引入了从日志文件中自动检索 NapCat Panel URL 和 token 的功能，通过添加版本检查改进了 NapCat 更新过程，并修复了读取 package.json 文件时的错误处理。

新功能：
- 引入了一项功能，如果配置中未提供 NapCat Panel URL 和 token，则可以从日志文件中自动检索它们。

Bug 修复：
- 修复了如果无法读取 package.json 文件会导致应用程序崩溃的问题，现在它会记录错误并返回默认版本。

增强功能：
- 改进了 NapCat 更新过程，通过在尝试下载和更新之前检查当前版本是否与最新的可用版本匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request introduces the ability to automatically retrieve the NapCat Panel URL and token from log files, improves the NapCat update process by adding a version check, and fixes error handling when reading the package.json file.

New Features:
- Introduced a feature to automatically retrieve the NapCat Panel URL and token from log files if they are not provided in the configuration.

Bug Fixes:
- Fixed an issue where the application would crash if the package.json file could not be read, now it logs the error and returns a default version.

Enhancements:
- Improved the NapCat update process by checking if the current version matches the latest available version before attempting to download and update.

</details>

</details>