### PR TITLE
v1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ---
 
 * 自动更新你的NapCat.Shell
-* 更新后自动快速登录你的NapCat
+* 更新后自动快速登录你的NapCat(支持从logs文件获取)
 
 ```
 将程序放在你的NapCat.Shell工作目录双击打开
@@ -16,6 +16,7 @@
 -version=v0.0.0(指定更新版本, 留空自动获得最新版)
 -debug=true(debug模式日志)
 -login=true(更新完成后等待进程启动自动登录NapCat)
+-skipcheck=false(跳过版本检查, 比如仅登录NapCat)
 -ncpanel=http://127.0.0.1:6099(NapCat默认url, 留空自动从logs获取)
 -nctoken=napcat(NapCat默认token, 留空自动从logs获取)
 -sleep=30s(等待NapCat登录超时的时间, 在此之后NapCatShellUpdater自动尝试登录)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NapCatShellUpdater
 
 ###### 仅考虑适配最新版
+###### 开发初衷只是为了更加方便的更新Windows平台下的NapCat.Shell所以只考虑Windows平台
 
 ---
 
@@ -9,5 +10,17 @@
 
 ```
 将程序放在你的NapCat.Shell工作目录双击打开
-或使用命令./NapCatShellUpdater -proxy=httpproxy -run=true ncpanel=http://127.0.0.1:6099 -nctoken=token -debug=true -login=true -version=v0.0.0 -sleep=30s
+
+或使用命令./NapCatShellUpdater
+-proxy=http://url:port(遵循proxy url规范)
+-version=v0.0.0(指定更新版本, 留空自动获得最新版)
+-debug=true(debug模式日志)
+-login=true(更新完成后等待进程启动自动登录NapCat)
+-ncpanel=http://127.0.0.1:6099(NapCat默认url, 留空自动从logs获取)
+-nctoken=napcat(NapCat默认token, 留空自动从logs获取)
+-sleep=30s(等待NapCat登录超时的时间, 在此之后NapCatShellUpdater自动尝试登录)
 ```
+
+---
+
+ - [NapNeko/NapCatQQ](https://github.com/NapNeko/NapCatQQ)

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@
 
 ```
 将程序放在你的NapCat.Shell工作目录双击打开
-或使用命令./NapCatShellUpdater -proxy=httpproxy -run=true ncpanel=http://127.0.0.1:6099 -nctoken=token -debug=true -login=true -version=v0.0.0
+或使用命令./NapCatShellUpdater -proxy=httpproxy -run=true ncpanel=http://127.0.0.1:6099 -nctoken=token -debug=true -login=true -version=v0.0.0 -sleep=30s
 ```

--- a/flags/init_flag.go
+++ b/flags/init_flag.go
@@ -9,12 +9,12 @@ import (
 
 var Config struct {
 	Path           string
+	Version        string
 	Proxy          string
 	Debug          bool
+	Login          bool
 	NapCatPanelURL string
 	NapCatToken    string
-	Login          bool
-	Version        string
 	Sleep          time.Duration
 }
 
@@ -27,12 +27,12 @@ func InitFlag() bool {
 		Config.Path = path
 		log.RPanic(err)
 	}
+	flag.StringVar(&Config.Version, "version", "", "Update NapCat Version")
 	flag.StringVar(&Config.Proxy, "proxy", "", "HTTP Proxy")
 	flag.BoolVar(&Config.Debug, "debug", true, "Enable debug logging")
-	flag.StringVar(&Config.NapCatPanelURL, "ncpanel", "http://127.0.0.1:6099", "NapCat Panel URL")
-	flag.StringVar(&Config.NapCatToken, "nctoken", "token", "NapCat Token")
 	flag.BoolVar(&Config.Login, "login", true, "Login to NapCat Panel")
-	flag.StringVar(&Config.Version, "version", "", "Update NapCat Version")
+	flag.StringVar(&Config.NapCatPanelURL, "ncpanel", "http://127.0.0.1:6099", "NapCat Panel URL")
+	flag.StringVar(&Config.NapCatToken, "nctoken", "napcat", "NapCat Token")
 	flag.DurationVar(&Config.Sleep, "sleep", 30*time.Second, "Sleep time(Wait NapCat load)")
 	flag.Parse()
 	return true

--- a/flags/init_flag.go
+++ b/flags/init_flag.go
@@ -12,6 +12,7 @@ var Config struct {
 	Version        string
 	Proxy          string
 	Debug          bool
+	SkipCheck      bool
 	Login          bool
 	NapCatPanelURL string
 	NapCatToken    string
@@ -30,6 +31,7 @@ func InitFlag() bool {
 	flag.StringVar(&Config.Version, "version", "", "Update NapCat Version")
 	flag.StringVar(&Config.Proxy, "proxy", "", "HTTP Proxy")
 	flag.BoolVar(&Config.Debug, "debug", true, "Enable debug logging")
+	flag.BoolVar(&Config.SkipCheck, "skipcheck", false, "Skip check NapCat version")
 	flag.BoolVar(&Config.Login, "login", true, "Login to NapCat Panel")
 	flag.StringVar(&Config.NapCatPanelURL, "ncpanel", "http://127.0.0.1:6099", "NapCat Panel URL")
 	flag.StringVar(&Config.NapCatToken, "nctoken", "napcat", "NapCat Token")

--- a/main.go
+++ b/main.go
@@ -40,11 +40,13 @@ $$ | \$$ \$$$$$$$ $$$$$$$  \$$$$$$  \$$$$$$$ |\$$$$  \$$$$$$  $$ |  $$ \$$$$$$$\
 }
 
 func main() {
-	cv := flags.Config.Version
-	if cv == "" {
-		napcat.CheckNapCatUpdate()
-	} else {
-		napcat.ProcessVersionUpdate(cv)
+	if !flags.Config.SkipCheck {
+		cv := flags.Config.Version
+		if cv == "" {
+			napcat.CheckNapCatUpdate()
+		} else {
+			napcat.ProcessVersionUpdate(cv)
+		}
 	}
 	if flags.Config.Login {
 		log.Info("NapCatShellUpdater", "Wating NapCat process to login...")


### PR DESCRIPTION
好的，这是将给定的 Pull Request 总结翻译成中文的结果：

## Sourcery 总结

更新 NapCat Shell Updater 以改进功能和用户体验。它引入了新功能，例如跳过版本检查和指定登录超时。 此更新还通过允许从日志中检索 NapCat URL 和令牌来增强自动登录过程。

增强功能：

- 通过允许从日志中检索 NapCat URL 和令牌来增强自动登录过程。
- 添加了一个 sleep 参数来配置登录超时。
- 改进了 README 中的命令行标志描述和使用说明。
- 添加了使用新标志跳过版本检查的功能。
- 使用更详细的说明和可用标志的解释来更新 README。
- 重构 main 函数以根据 skipcheck 标志有条件地检查更新。
- 重新排列 init_flag.go 文件中标志的顺序，以实现更好的组织。
- 更新 NapCat Panel URL 和 Token 标志的默认值，以方便从日志中自动检索。
- 在 README 中添加注释，以阐明应用程序的预期平台和目的。
- 更新 README 以包含代理 URL 规范。
- 在 README 文件的末尾添加一个新行，以符合格式标准。
- 在 flags/init_flag.go 文件的末尾添加一个新行，以符合格式标准。
- 在 main.go 文件的末尾添加一个新行，以符合格式标准。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Updates the NapCat Shell Updater to improve functionality and user experience. It introduces new features such as skipping version checks and specifying a login timeout. The update also enhances the automatic login process by allowing the retrieval of NapCat URL and token from logs.

Enhancements:
- Enhances the automatic login process by allowing the retrieval of NapCat URL and token from logs.
- Adds a sleep parameter to configure the login timeout.
- Improves command-line flag descriptions and usage instructions in the README.
- Adds the ability to skip version checks using a new flag.
- Updates the README with more detailed instructions and explanations of the available flags.
- Refactors the main function to conditionally check for updates based on the skipcheck flag.
- Rearranges the order of flags in the init_flag.go file for better organization.
- Updates default values for NapCat Panel URL and Token flags to facilitate automatic retrieval from logs.
- Adds comments to the README to clarify the intended platform and purpose of the application.
- Updates the README to include proxy URL specifications.
- Adds a new line at the end of the README file to comply with formatting standards.
- Adds a new line at the end of the flags/init_flag.go file to comply with formatting standards.
- Adds a new line at the end of the main.go file to comply with formatting standards.

</details>